### PR TITLE
Added pomOnly tag to netlib

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "org.apache.commons" % "commons-compress" % "1.7",
   "commons-io" % "commons-io" % "2.4",
   "org.scalanlp" % "breeze_2.10" % "0.9",
-  "com.github.fommil.netlib" % "all" % "1.1.2",
+  "com.github.fommil.netlib" % "all" % "1.1.2" pomOnly(),
   "edu.berkeley.cs.amplab" % "mlmatrix" % "0.1" from "https://s3-us-west-1.amazonaws.com/amp-ml-matrix/2.10/mlmatrix_2.10-0.1.jar",
   "com.github.scopt" %% "scopt" % "3.3.0"
 )


### PR DESCRIPTION
Required for maven projects to correctly read a locally-published keystone project
@etrain @shivaram 
