### PR TITLE
Normalize data before linear model fitting

### DIFF
--- a/src/main/scala/nodes/learning/LinearDiscriminantAnalysis.scala
+++ b/src/main/scala/nodes/learning/LinearDiscriminantAnalysis.scala
@@ -62,7 +62,7 @@ class LinearDiscriminantAnalysis(numDimensions: Int) extends LabelEstimator[Dens
     val topEigenvectors = eigenvectors.zip(eigen.eigenvalues.toArray).sortBy(x => -math.abs(x._2)).map(_._1).take(numDimensions)
     val W = DenseMatrix.horzcat(topEigenvectors:_*)
 
-    new LinearMapper(W, DenseVector.zeros(W.cols))
+    new LinearMapper(W)
   }
 }
 

--- a/src/test/scala/nodes/learning/BlockLinearMapperSuite.scala
+++ b/src/test/scala/nodes/learning/BlockLinearMapperSuite.scala
@@ -23,8 +23,8 @@ class BlockLinearMapperSuite extends FunSuite with LocalSparkContext with Loggin
     val splitVec = (0 until numChunks).map(i => vec((numPerChunk*i) until (numPerChunk*i + numPerChunk)))
     val splitMat = (0 until numChunks).map(i => mat((numPerChunk*i) until (numPerChunk*i + numPerChunk), ::))
 
-    val linearMapper = new LinearMapper(mat, DenseVector.zeros(mat.cols))
-    val blockLinearMapper = new BlockLinearMapper(splitMat, DenseVector.zeros(mat.cols))
+    val linearMapper = new LinearMapper(mat)
+    val blockLinearMapper = new BlockLinearMapper(splitMat)
 
     assert(Stats.aboutEq(blockLinearMapper(splitVec), linearMapper(vec), 1e-4))
   }


### PR DESCRIPTION
This enables us to avoid using intercepts while fitting linear models. This PR also includes a minor build change to exclude Hadoop dependencies pulled in from Spark.

@etrain @tomerk This does make the BlockLinearMapper / LinearMapper node more complex to use for other purpose. Let me know if there is a better way around this. Will add a unit test tomorrow

Closes #95
