### PR TITLE
Adding fix for block cifar.

### DIFF
--- a/src/main/scala/pipelines/images/cifar/RandomPatchCifar.scala
+++ b/src/main/scala/pipelines/images/cifar/RandomPatchCifar.scala
@@ -65,7 +65,7 @@ object RandomPatchCifar extends Serializable with Logging {
     val trainFeatures = featurizer(trainImages)
     val trainLabels = labelExtractor(trainData)
 
-    val model = new BlockLeastSquaresEstimator(4096, 1, conf.lambda.getOrElse(0.0)).fit(trainFeatures, trainData)
+    val model = new BlockLeastSquaresEstimator(4096, 1, conf.lambda.getOrElse(0.0)).fit(trainFeatures, trainLabels)
 
     val predictionPipeline = featurizer then model then MaxClassifier then new Cacher[Int]
 

--- a/src/main/scala/pipelines/images/cifar/RandomPatchCifar.scala
+++ b/src/main/scala/pipelines/images/cifar/RandomPatchCifar.scala
@@ -5,7 +5,7 @@ import breeze.numerics._
 import evaluation.MulticlassClassifierEvaluator
 import loaders.CifarLoader
 import nodes.images._
-import nodes.learning.{LinearMapEstimator, ZCAWhitener, ZCAWhitenerEstimator}
+import nodes.learning.{BlockLeastSquaresEstimator, ZCAWhitener, ZCAWhitenerEstimator}
 import nodes.stats.{StandardScaler, Sampler}
 import nodes.util.{Cacher, ClassLabelIndicatorsFromIntLabels, MaxClassifier}
 import org.apache.spark.{SparkConf, SparkContext}
@@ -65,7 +65,7 @@ object RandomPatchCifar extends Serializable with Logging {
     val trainFeatures = featurizer(trainImages)
     val trainLabels = labelExtractor(trainData)
 
-    val model = LinearMapEstimator(conf.lambda).fit(trainFeatures, trainLabels)
+    val model = new BlockLeastSquaresEstimator(4096, 1, conf.lambda.getOrElse(0.0)).fit(trainFeatures, trainData)
 
     val predictionPipeline = featurizer then model then MaxClassifier then new Cacher[Int]
 


### PR DESCRIPTION
Makes RandomPatchCifar pipeline use block coordinate descent for scalability beyond 1000 filters (or 4k features)