### PR TITLE
Following redirects and failing on 404 with missing jars.

### DIFF
--- a/sbt/sbt
+++ b/sbt/sbt
@@ -30,9 +30,9 @@ if [ ! -f ${JAR} ]; then
   # Download
   printf "Attempting to fetch sbt\n"
   if hash curl 2>/dev/null; then
-    curl --progress-bar ${URL1} > ${JAR} || curl --progress-bar ${URL2} > ${JAR}
+    curl --fail --location --silent ${URL1} > ${JAR} || curl --fail --location --silent ${URL2} > ${JAR}
   elif hash wget 2>/dev/null; then
-    wget --progress=bar ${URL1} -O ${JAR} || wget --progress=bar ${URL2} -O ${JAR}
+    wget --quiet ${URL1} -O ${JAR} || wget --quiet ${URL2} -O ${JAR}
   else
     printf "You do not have curl or wget installed, please install sbt manually from http://www.scala-sbt.org/\n"
     exit -1


### PR DESCRIPTION
This patch fixes issues with corrupt jar files when trying to build a fresh checkout of KeystoneML according to the instructions on the project webpage.

I went with the minimal set of changes to get this working again here.

We could also more closely mirror the sbt scripts of Spark, but that was a more invasive change than I wanted to make to get this bugfix in.

Thanks @ericmjonas and Dimp Bhat for reporting.

cc @shivaram @tomerk 