### PR TITLE
Fix residual mean computation

### DIFF
--- a/src/main/scala/nodes/learning/BlockWeightedLeastSquares.scala
+++ b/src/main/scala/nodes/learning/BlockWeightedLeastSquares.scala
@@ -162,14 +162,7 @@ object BlockWeightedLeastSquaresEstimator extends Logging {
       mat(*, ::) :- jointLabelMean
     }.cache().setName("residual")
 
-    val residualSumCount = MLMatrixUtils.treeReduce(residual.map { mat =>
-      (sum(mat(::, *)).toDenseVector, mat.rows)
-    }, (a: (DenseVector[Double], Int), b: (DenseVector[Double], Int)) => {
-      a._1 += b._1
-      (a._1, a._2 + b._2)
-    })
-
-    var residualMean = residualSumCount._1 /= residualSumCount._2.toDouble
+    var residualMean = MatrixUtils.computeMean(residual)
 
     @transient val blockStats: Array[Option[BlockStatistics]] = (0 until numBlocks).map { blk =>
       None
@@ -289,14 +282,7 @@ object BlockWeightedLeastSquaresEstimator extends Logging {
         residual.unpersist()
         residual = newResidual
 
-        val residualSumCount = MLMatrixUtils.treeReduce(residual.map { mat =>
-          (sum(mat(::, *)).toDenseVector, mat.rows)
-        }, (a: (DenseVector[Double], Int), b: (DenseVector[Double], Int)) => {
-          a._1 += b._1
-          (a._1, a._2 + b._2)
-        })
-
-        residualMean = residualSumCount._1 /= residualSumCount._2.toDouble
+        residualMean = MatrixUtils.computeMean(residual)
 
         popCovBC.unpersist()
         popMeanBC.unpersist()

--- a/src/main/scala/utils/MatrixUtils.scala
+++ b/src/main/scala/utils/MatrixUtils.scala
@@ -7,6 +7,9 @@ import breeze.linalg._
 import scala.reflect.ClassTag
 import scala.util.Random
 
+import org.apache.spark.rdd.RDD
+
+import edu.berkeley.cs.amplab.mlmatrix.util.{Utils => MLMatrixUtils}
 
 /**
  * A collection of utilities useful for matrices.
@@ -92,6 +95,17 @@ object MatrixUtils extends Serializable {
       i = i - 1
     }
     arr
+  }
+
+  def computeMean(in: RDD[DenseMatrix[Double]]): DenseVector[Double] = {
+    val sumCount = MLMatrixUtils.treeReduce(in.map { mat =>
+      (sum(mat(::, *)).toDenseVector, mat.rows)
+    }, (a: (DenseVector[Double], Int), b: (DenseVector[Double], Int)) => {
+      a._1 += b._1
+      (a._1, a._2 + b._2)
+    })
+
+    sumCount._1 /= sumCount._2.toDouble
   }
 
 }

--- a/src/test/scala/utils/MatrixUtilsSuite.scala
+++ b/src/test/scala/utils/MatrixUtilsSuite.scala
@@ -1,0 +1,29 @@
+package utils
+
+import org.scalatest.FunSuite
+
+import breeze.linalg._
+import breeze.stats._
+
+import org.apache.spark.SparkContext
+
+import pipelines._
+
+class MatrixUtilsSuite extends FunSuite with LocalSparkContext {
+
+  test("computeMean works correctly") {
+    val numRows = 1000
+    val numCols = 32
+    val numParts = 4
+    sc = new SparkContext("local", "test")
+    val in = DenseMatrix.rand(numRows, numCols)
+    val inArr = MatrixUtils.matrixToRowArray(in)
+    val rdd = sc.parallelize(inArr, numParts).mapPartitions { iter => 
+      Iterator.single(MatrixUtils.rowsToMatrix(iter))
+    }
+    val expected = mean(in(::, *)).toDenseVector
+    val actual = MatrixUtils.computeMean(rdd)
+    assert(Stats.aboutEq(expected, actual, 1e-6))
+  }
+
+}


### PR DESCRIPTION
The previous approach of computing per-partition mean only works when number of elements per-class is equal. To fix it we now compute the sum per partition and the count per partition.

Many thanks to @tomerk and @ericmjonas for providing a test case. FWIW it wasn't being caught by the unit tests as we had equal number of elements per class in them. I'll add a unit test with uneven number of examples per class.

cc @rolloff