### PR TITLE
Fixing daisy feature ordering to match SIFT. Closes #186.

### DIFF
--- a/src/main/scala/nodes/images/DaisyExtractor.scala
+++ b/src/main/scala/nodes/images/DaisyExtractor.scala
@@ -187,7 +187,7 @@ class DaisyExtractor(
       }
       x += 1
     }
-    out
+    out.t //Note: to match SIFT, the output should be daisyFeatureSize x num-descriptors.
   }
 
   def normalize(x: DenseVector[Double]): DenseVector[Double] = {

--- a/src/test/scala/nodes/images/DaisyExtractorSuite.scala
+++ b/src/test/scala/nodes/images/DaisyExtractorSuite.scala
@@ -14,7 +14,7 @@ class DaisyExtractorSuite extends FunSuite with Logging {
     val df = new DaisyExtractor()
     val daisyDescriptors = convert(df.apply(grayImage), Double)
 
-    val firstKeyPointSum = sum(daisyDescriptors(0, ::))
+    val firstKeyPointSum = sum(daisyDescriptors(::, 0))
     val fullFeatureSum = sum(daisyDescriptors)
 
     // Values found from running matlab code on same input file.

--- a/src/test/scala/nodes/images/DaisyExtractorSuite.scala
+++ b/src/test/scala/nodes/images/DaisyExtractorSuite.scala
@@ -1,6 +1,7 @@
 package nodes.images
 
 import breeze.linalg._
+import nodes.images.external.SIFTExtractor
 import org.scalatest.FunSuite
 
 import pipelines.Logging
@@ -27,5 +28,19 @@ class DaisyExtractorSuite extends FunSuite with Logging {
       "First keypoint sum must match for Daisy")
     assert(Stats.aboutEq((fullFeatureSum - matlabFullFeatureSum)/matlabFullFeatureSum, 0, 1e-7),
       "Sum of Daisys must match expected sum")
+  }
+
+  test("Daisy and SIFT extractors should have same row/column ordering.") {
+    val testImage = TestUtils.loadTestImage("images/gantrycrane.png")
+    val grayImage = ImageUtils.toGrayScale(testImage)
+
+    val df = new DaisyExtractor()
+    val daisyDescriptors = convert(df.apply(grayImage), Double)
+
+    val se = SIFTExtractor(scaleStep = 2)
+    val siftDescriptors = se.apply(grayImage)
+
+    assert(daisyDescriptors.rows == df.daisyFeatureSize && siftDescriptors.rows == se.descriptorSize)
+
   }
 }


### PR DESCRIPTION
This fix transposes the order of features coming out of the Daisy Extractor so that it's a drop in replacement for the SIFT featurizer -- logically these things do different things but at least "Image Descriptors" should have a common structure. Closes #186 