### PR TITLE
Fixing VectorSplitter irregular block size issue and adding unit test.

### DIFF
--- a/src/main/scala/nodes/util/VectorSplitter.scala
+++ b/src/main/scala/nodes/util/VectorSplitter.scala
@@ -29,7 +29,8 @@ class VectorSplitter(
     val numBlocks = math.ceil(numFeatures.toDouble / blockSize).toInt
     (0 until numBlocks).map { blockNum =>
       // Expliclity call toArray as breeze's slice is lazy
-      DenseVector(in.slice(blockNum * blockSize, (blockNum + 1) * blockSize).toArray)
+      val end = math.min(numFeatures, (blockNum + 1) * blockSize)
+      DenseVector(in.slice(blockNum * blockSize, end).toArray)
     }
   }
 }

--- a/src/test/scala/nodes/util/VectorSplitterSuite.scala
+++ b/src/test/scala/nodes/util/VectorSplitterSuite.scala
@@ -1,0 +1,23 @@
+package nodes.util
+
+import breeze.linalg.DenseVector
+import org.scalatest.FunSuite
+
+class VectorSplitterSuite extends FunSuite {
+  test("vector splitter") {
+    for (
+      bs <- Array(128, 256, 512, 1024, 2048);
+      mul <- 0 to 2;
+      off <- 0 to 20 by 5;
+      feats <- Array(Some(bs*mul+off), None)
+    ) {
+      val sp = new VectorSplitter(bs, feats)
+      val vec = DenseVector.zeros[Double](bs*mul+off)
+
+      val expectedSplits = (bs*mul+off)/bs + (if ((bs*mul+off)%bs == 0) 0 else 1)
+
+      assert(sp.splitVector(vec).length === expectedSplits,
+        s"True length is ${sp.splitVector(vec).length}, expected length is ${expectedSplits}")
+    }
+  }
+}

--- a/src/test/scala/nodes/util/VectorSplitterSuite.scala
+++ b/src/test/scala/nodes/util/VectorSplitterSuite.scala
@@ -1,6 +1,6 @@
 package nodes.util
 
-import breeze.linalg.DenseVector
+import breeze.linalg._
 import org.scalatest.FunSuite
 
 class VectorSplitterSuite extends FunSuite {
@@ -9,15 +9,32 @@ class VectorSplitterSuite extends FunSuite {
       bs <- Array(128, 256, 512, 1024, 2048);
       mul <- 0 to 2;
       off <- 0 to 20 by 5;
-      feats <- Array(Some(bs*mul+off), None)
+      feats <- Array(Some(bs*mul + off), None)
     ) {
       val sp = new VectorSplitter(bs, feats)
-      val vec = DenseVector.zeros[Double](bs*mul+off)
+      val vec = DenseVector.zeros[Double](bs*mul + off)
 
-      val expectedSplits = (bs*mul+off)/bs + (if ((bs*mul+off)%bs == 0) 0 else 1)
+      val expectedSplits = (bs*mul + off)/bs + (if ((bs*mul + off) % bs == 0) 0 else 1)
 
       assert(sp.splitVector(vec).length === expectedSplits,
         s"True length is ${sp.splitVector(vec).length}, expected length is ${expectedSplits}")
+    }
+  }
+
+  test("vector splitter maintains order") {
+    for (
+      bs <- Array(128, 256, 512, 1024, 2048);
+      mul <- 0 to 2;
+      off <- 0 to 20 by 5;
+      feats <- Array(Some(bs*mul + off), None)
+    ) {
+      val sp = new VectorSplitter(bs, feats)
+      val vec = rand(bs*mul + off)
+
+      val expectedSplits = (bs*mul + off) / bs + (if ((bs*mul+off) % bs == 0) 0 else 1)
+
+      assert(DenseVector.vertcat(sp.splitVector(vec):_*) === vec,
+        s"Recombinded split vector of length ${bs*mul + off} with block size $bs did not match its input")
     }
   }
 }

--- a/src/test/scala/nodes/util/VectorSplitterSuite.scala
+++ b/src/test/scala/nodes/util/VectorSplitterSuite.scala
@@ -31,8 +31,6 @@ class VectorSplitterSuite extends FunSuite {
       val sp = new VectorSplitter(bs, feats)
       val vec = rand(bs*mul + off)
 
-      val expectedSplits = (bs*mul + off) / bs + (if ((bs*mul+off) % bs == 0) 0 else 1)
-
       assert(DenseVector.vertcat(sp.splitVector(vec):_*) === vec,
         s"Recombinded split vector of length ${bs*mul + off} with block size $bs did not match its input")
     }


### PR DESCRIPTION
This adds a fix for the non-apply method in VectorSplitter which doesn't have a proper termination condition when the blocksize is not an exact multiple of the vector size.

Closes #188 