### PR TITLE
Changing default ZCA Whitener regularization parameter and adding documentation.

### DIFF
--- a/src/main/scala/nodes/learning/ZCAWhitener.scala
+++ b/src/main/scala/nodes/learning/ZCAWhitener.scala
@@ -17,7 +17,14 @@ class ZCAWhitener(val whitener: DenseMatrix[Double], val means: DenseVector[Doub
   }
 }
 
-class ZCAWhitenerEstimator(val eps: Double = 1e-12)
+/**
+  * Computes a ZCA Whitener, which is intended to rotate an input dataset to identity covariance.
+  * The "Z" in ZCA Whitening means that the solution will be as close to the original dataset as possible while having
+  * this identity covariance property.
+  *
+  * @param eps Regularization Parameter
+  */
+class ZCAWhitenerEstimator(val eps: Double = 0.1)
   extends Estimator[DenseMatrix[Double],DenseMatrix[Double]] {
 
   def fit(in: RDD[DenseMatrix[Double]]): ZCAWhitener = {

--- a/src/main/scala/nodes/learning/ZCAWhitener.scala
+++ b/src/main/scala/nodes/learning/ZCAWhitener.scala
@@ -22,6 +22,9 @@ class ZCAWhitener(val whitener: DenseMatrix[Double], val means: DenseVector[Doub
   * The "Z" in ZCA Whitening means that the solution will be as close to the original dataset as possible while having
   * this identity covariance property.
   *
+  * See here for more details:
+  * http://ufldl.stanford.edu/wiki/index.php/Whitening
+  *
   * @param eps Regularization Parameter
   */
 class ZCAWhitenerEstimator(val eps: Double = 0.1)

--- a/src/main/scala/pipelines/images/cifar/RandomPatchCifar.scala
+++ b/src/main/scala/pipelines/images/cifar/RandomPatchCifar.scala
@@ -38,7 +38,7 @@ object RandomPatchCifar extends Serializable with Logging {
     val (filters, whitener): (DenseMatrix[Double], ZCAWhitener) = {
         val baseFilters = patchExtractor(trainImages)
         val baseFilterMat = Stats.normalizeRows(MatrixUtils.rowsToMatrix(baseFilters), 10.0)
-        val whitener = new ZCAWhitenerEstimator().fitSingle(baseFilterMat)
+        val whitener = new ZCAWhitenerEstimator(eps=conf.whiteningEpsilon).fitSingle(baseFilterMat)
 
         //Normalize them.
         val sampleFilters = MatrixUtils.sampleRows(baseFilterMat, conf.numFilters)
@@ -89,6 +89,7 @@ object RandomPatchCifar extends Serializable with Logging {
       trainLocation: String = "",
       testLocation: String = "",
       numFilters: Int = 100,
+      whiteningEpsilon: Double = 0.1,
       patchSize: Int = 6,
       patchSteps: Int = 1,
       poolSize: Int = 14,
@@ -102,6 +103,7 @@ object RandomPatchCifar extends Serializable with Logging {
     help("help") text("prints this usage text")
     opt[String]("trainLocation") required() action { (x,c) => c.copy(trainLocation=x) }
     opt[String]("testLocation") required() action { (x,c) => c.copy(testLocation=x) }
+    opt[Double]("whiteningEpsilon") required() action { (x,c) => c.copy(whiteningEpsilon=x) }
     opt[Int]("numFilters") action { (x,c) => c.copy(numFilters=x) }
     opt[Int]("patchSize") action { (x,c) => c.copy(patchSize=x) }
     opt[Int]("patchSteps") action { (x,c) => c.copy(patchSteps=x) }


### PR DESCRIPTION
Adding some docs and changing the default regularization parameter. This significantly improves accuracy on e.g. the CIFAR pipeline and will in general improve accuracy when input data has very small singular values, which you'd expect to be the case in "compressible" data.

Closes #190 