### PR TITLE
Node-level optimization generalization

### DIFF
--- a/src/main/scala/workflow/DefaultOptimizer.scala
+++ b/src/main/scala/workflow/DefaultOptimizer.scala
@@ -7,7 +7,7 @@ import workflow.AutoCacheRule.GreedyCache
  */
 object DefaultOptimizer extends Optimizer {
   protected val batches: Seq[Batch] =
-    Batch("DAG Optimization", FixedPoint(Int.MaxValue), EquivalentNodeMergeRule) ::
+    Batch("Common Sub-expression Elimination", FixedPoint(Int.MaxValue), EquivalentNodeMergeRule) ::
     Batch("Node Level Optimization", Once, new NodeOptimizationRule) ::
     Batch("Common Sub-expression Elimination", FixedPoint(Int.MaxValue), EquivalentNodeMergeRule) ::
       Nil
@@ -18,8 +18,9 @@ object DefaultOptimizer extends Optimizer {
  */
 class AutoCachingOptimizer(strategy: AutoCacheRule.CachingStrategy = GreedyCache()) extends Optimizer {
   protected val batches: Seq[Batch] =
-    Batch("DAG Optimization", FixedPoint(100), EquivalentNodeMergeRule) ::
+    Batch("Common Sub-expression Elimination", FixedPoint(Int.MaxValue), EquivalentNodeMergeRule) ::
     Batch("Node Level Optimization", Once, new NodeOptimizationRule) ::
+    Batch("Common Sub-expression Elimination", FixedPoint(Int.MaxValue), EquivalentNodeMergeRule) ::
     Batch("Auto Cache", Once, new AutoCacheRule(strategy)) ::
       Nil
 }

--- a/src/main/scala/workflow/DefaultOptimizer.scala
+++ b/src/main/scala/workflow/DefaultOptimizer.scala
@@ -7,8 +7,9 @@ import workflow.AutoCacheRule.GreedyCache
  */
 object DefaultOptimizer extends Optimizer {
   protected val batches: Seq[Batch] =
-    Batch("DAG Optimization", FixedPoint(100), EquivalentNodeMergeRule) ::
+    Batch("DAG Optimization", FixedPoint(Int.MaxValue), EquivalentNodeMergeRule) ::
     Batch("Node Level Optimization", Once, new NodeOptimizationRule) ::
+    Batch("Common Sub-expression Elimination", FixedPoint(Int.MaxValue), EquivalentNodeMergeRule) ::
       Nil
 }
 

--- a/src/main/scala/workflow/NodeOptimizationRule.scala
+++ b/src/main/scala/workflow/NodeOptimizationRule.scala
@@ -11,25 +11,24 @@ class NodeOptimizationRule(sampleFraction: Double = 0.01, seed: Long = 0) extend
   override def apply[A, B](plan: Pipeline[A, B]): Pipeline[A, B] = {
     val instructions = WorkflowUtils.pipelineToInstructions(plan)
 
-    // First, figure out which instructions we should actually execute.
-    // Take the set of all instructions that are parents of an optimizable node transform or fit instruction.
+    // First, figure out which instructions we should actually optimize and execute.
+    // Execute the set of all instructions that are parents of an optimizable node transform or fit instruction.
     // And, keep those that do not depend on the runtime input of a fit pipeline
-    val instructionsToExecute = instructions.zipWithIndex.map {
-      case (TransformerApplyNode(tIndex, _), index) =>
-        instructions(tIndex) match {
-          case _: OptimizableTransformer[_, _] => WorkflowUtils.getParents(index, instructions) + index
-          case _ => Set[Int]()
-        }
+    val instructionsToOptimize = instructions.zipWithIndex.collect {
+      case (TransformerApplyNode(tIndex, _), index)
+        if instructions(tIndex).isInstanceOf[OptimizableTransformer[_, _]] => index
 
-      case (EstimatorFitNode(estIndex, _), index) =>
-        instructions(estIndex) match {
-          case _: OptimizableEstimator[_, _] => WorkflowUtils.getParents(index, instructions) + index
-          case _: OptimizableLabelEstimator[_, _, _] => WorkflowUtils.getParents(index, instructions) + index
-          case _ => Set[Int]()
-        }
+      case (EstimatorFitNode(estIndex, _), index)
+        if instructions(estIndex).isInstanceOf[OptimizableEstimator[_, _]] => index
 
-      case _ => Set[Int]()
-    }.reduce(_ union _) -- WorkflowUtils.getChildren(Pipeline.SOURCE, instructions) - Pipeline.SOURCE
+      case (EstimatorFitNode(estIndex, _), index)
+        if instructions(estIndex).isInstanceOf[OptimizableLabelEstimator[_, _, _]] => index
+
+    }.toSet -- WorkflowUtils.getChildren(Pipeline.SOURCE, instructions)
+
+    val instructionsToExecute = instructionsToOptimize.map {
+      index => WorkflowUtils.getParents(index, instructions)
+    }.fold(Set[Int]())(_ union _)
 
     // Execute the minimal amount necessary of the pipeline on sampled nodes, and optimize the optimizable nodes
     var optimizedInstructions = instructions
@@ -37,7 +36,8 @@ class NodeOptimizationRule(sampleFraction: Double = 0.01, seed: Long = 0) extend
     val registers = new Array[InstructionOutput](instructions.length)
     val numPerPartitionPerNode = Array.fill[Option[Map[Int, Int]]](instructions.length)(None)
 
-    for ((instruction, index) <- instructions.zipWithIndex if instructionsToExecute.contains(index)) {
+    for ((instruction, index) <- instructions.zipWithIndex
+         if instructionsToExecute.contains(index) || instructionsToOptimize.contains(index)) {
       instruction match {
         case SourceNode(rdd) => {
           val sampledRDD = rdd.sample(withReplacement = false, sampleFraction, seed)
@@ -55,37 +55,40 @@ class NodeOptimizationRule(sampleFraction: Double = 0.01, seed: Long = 0) extend
           // Optimize the transformer if possible
           val transformer = registers(tIndex) match {
             case TransformerOutput(ot: OptimizableTransformer[a, b]) =>
-              val pipeToSplice = ot.optimize(inputs.head.asInstanceOf[RDD[a]], numPerPartition.get)
-              val instructionsToSplice = WorkflowUtils.pipelineToInstructions(pipeToSplice)
+              if (instructionsToOptimize.contains(index)) {
+                val pipeToSplice = ot.optimize(inputs.head.asInstanceOf[RDD[a]], numPerPartition.get)
+                val instructionsToSplice = WorkflowUtils.pipelineToInstructions(pipeToSplice)
 
-              // First: Disconnect all the dependencies in the optimized pipeline on this TransformerApplyNode,
-              // and replace them with the spliceEndpoint
-              val spliceEndpoint = Pipeline.SOURCE - 1
-              val indexInNewPipeline = oldIndexToNewIndex(index)
-              val removeResult = WorkflowUtils.disconnectAndRemoveInstructions(
-                Map(indexInNewPipeline -> spliceEndpoint),
-                optimizedInstructions)
-              optimizedInstructions = removeResult._1
-              oldIndexToNewIndex = oldIndexToNewIndex andThen removeResult._2
+                // First: Disconnect all the dependencies in the optimized pipeline on this TransformerApplyNode,
+                // and replace them with the spliceEndpoint
+                val spliceEndpoint = Pipeline.SOURCE - 1
+                val indexInNewPipeline = oldIndexToNewIndex(index)
+                val removeResult = WorkflowUtils.disconnectAndRemoveInstructions(
+                  Map(indexInNewPipeline -> spliceEndpoint),
+                  optimizedInstructions)
+                optimizedInstructions = removeResult._1
+                oldIndexToNewIndex = oldIndexToNewIndex andThen removeResult._2
 
-              // Then: Splice in the transformer's optimization into the optimized pipeline
-              // Note: We do not delete the optimizable transformer because it may be used elsewhere
-              // if we've merged equivalent TransformerNodes.
-              val spliceResult = WorkflowUtils.spliceInstructions(
-                instructionsToSplice,
-                optimizedInstructions,
-                Map(Pipeline.SOURCE -> oldIndexToNewIndex(inputIndices.head)),
-                spliceEndpoint)
-              optimizedInstructions = spliceResult._1
-              oldIndexToNewIndex = oldIndexToNewIndex andThen spliceResult._2
-
+                // Then: Splice in the transformer's optimization into the optimized pipeline
+                // Note: We do not delete the optimizable transformer because it may be used elsewhere
+                // if we've merged equivalent TransformerNodes.
+                val spliceResult = WorkflowUtils.spliceInstructions(
+                  instructionsToSplice,
+                  optimizedInstructions,
+                  Map(Pipeline.SOURCE -> oldIndexToNewIndex(inputIndices.head)),
+                  spliceEndpoint)
+                optimizedInstructions = spliceResult._1
+                oldIndexToNewIndex = oldIndexToNewIndex andThen spliceResult._2
+              }
               ot
             case TransformerOutput(t) => t
             case _ => throw new ClassCastException("TransformerApplyNode dep wasn't pointing at a transformer")
           }
 
-          registers(index) = RDDOutput(transformer.transformRDD(inputs))
-          numPerPartitionPerNode(index) = numPerPartition
+          if (instructionsToExecute.contains(index)) {
+            registers(index) = RDDOutput(transformer.transformRDD(inputs))
+            numPerPartitionPerNode(index) = numPerPartition
+          }
         }
 
         case EstimatorFitNode(estIndex, inputIndices) => {
@@ -98,129 +101,134 @@ class NodeOptimizationRule(sampleFraction: Double = 0.01, seed: Long = 0) extend
           // Optimize the estimator if possible
           val estimator = registers(estIndex) match {
             case EstimatorOutput(oe: OptimizableEstimator[a, b]) =>
-              val spliceEndpoint = Pipeline.SOURCE - 1
+              if (instructionsToOptimize.contains(index)) {
+                val spliceEndpoint = Pipeline.SOURCE - 1
 
-              // Get the instructions to splice into the optimized pipeline
-              val dataSample = inputs.head.asInstanceOf[RDD[a]]
-              val pipeToSplice = oe.optimize(dataSample, numPerPartition.get).apply(dataSample)
-              val initialInstructionsToSplice = WorkflowUtils.pipelineToInstructions(pipeToSplice)
-              val dataSampleIndices = initialInstructionsToSplice.indices.filter {
-                initialInstructionsToSplice(_) == SourceNode(dataSample)
-              }.toSet
-              val instructionsToSplice = WorkflowUtils.disconnectAndRemoveInstructions(
-                dataSampleIndices.map(_ -> spliceEndpoint).toMap,
-                initialInstructionsToSplice
-              )._1
+                // Get the instructions to splice into the optimized pipeline
+                val dataSample = inputs.head.asInstanceOf[RDD[a]]
+                val pipeToSplice = oe.optimize(dataSample, numPerPartition.get).apply(dataSample)
+                val initialInstructionsToSplice = WorkflowUtils.pipelineToInstructions(pipeToSplice)
+                val dataSampleIndices = initialInstructionsToSplice.indices.filter {
+                  initialInstructionsToSplice(_) == SourceNode(dataSample)
+                }.toSet
+                val instructionsToSplice = WorkflowUtils.disconnectAndRemoveInstructions(
+                  dataSampleIndices.map(_ -> spliceEndpoint).toMap,
+                  initialInstructionsToSplice
+                )._1
 
-              // First: Disconnect all the dependencies in the optimized pipeline on this EstimatorFitNode,
-              // and remove this node
-              val indexInNewPipeline = oldIndexToNewIndex(index)
-              val removeResult = WorkflowUtils.disconnectAndRemoveInstructions(
-                Map(indexInNewPipeline -> (spliceEndpoint - 1)),
-                optimizedInstructions)
-              optimizedInstructions = removeResult._1
-              oldIndexToNewIndex = oldIndexToNewIndex andThen removeResult._2
+                // First: Disconnect all the dependencies in the optimized pipeline on this EstimatorFitNode,
+                // and remove this node
+                val indexInNewPipeline = oldIndexToNewIndex(index)
+                val removeResult = WorkflowUtils.disconnectAndRemoveInstructions(
+                  Map(indexInNewPipeline -> (spliceEndpoint - 1)),
+                  optimizedInstructions)
+                optimizedInstructions = removeResult._1
+                oldIndexToNewIndex = oldIndexToNewIndex andThen removeResult._2
 
-              instructions.zipWithIndex.foreach {
-                case (TransformerApplyNode(t, tInputs), transformerApplyIndex) if t == index => {
-                  // First: Disconnect all the dependencies in the optimized pipeline on this TransformerApplyNode,
-                  // and replace them with the spliceEndpoint
+                instructions.zipWithIndex.foreach {
+                  case (TransformerApplyNode(t, tInputs), transformerApplyIndex) if t == index => {
+                    // First: Disconnect all the dependencies in the optimized pipeline on this TransformerApplyNode,
+                    // and replace them with the spliceEndpoint
 
-                  val indexInNewPipeline = oldIndexToNewIndex(transformerApplyIndex)
-                  val removeResult = WorkflowUtils.disconnectAndRemoveInstructions(
-                    Map(indexInNewPipeline -> spliceEndpoint),
-                    optimizedInstructions)
-                  optimizedInstructions = removeResult._1
-                  oldIndexToNewIndex = oldIndexToNewIndex andThen removeResult._2
+                    val indexInNewPipeline = oldIndexToNewIndex(transformerApplyIndex)
+                    val removeResult = WorkflowUtils.disconnectAndRemoveInstructions(
+                      Map(indexInNewPipeline -> spliceEndpoint),
+                      optimizedInstructions)
+                    optimizedInstructions = removeResult._1
+                    oldIndexToNewIndex = oldIndexToNewIndex andThen removeResult._2
 
-                  // Then: Splice in the transformer's optimization into the optimized pipeline
-                  // Note: We do not delete the optimizable transformer because it may be used elsewhere
-                  // if we've merged equivalent TransformerNodes.
-                  val spliceResult = WorkflowUtils.spliceInstructions(
-                    instructionsToSplice,
-                    optimizedInstructions,
-                    Map(spliceEndpoint -> oldIndexToNewIndex(inputIndices.head),
-                      Pipeline.SOURCE -> oldIndexToNewIndex(tInputs.head)),
-                    spliceEndpoint)
-                  optimizedInstructions = spliceResult._1
-                  oldIndexToNewIndex = oldIndexToNewIndex andThen spliceResult._2
+                    // Then: Splice in the transformer's optimization into the optimized pipeline
+                    // Note: We do not delete the optimizable transformer because it may be used elsewhere
+                    // if we've merged equivalent TransformerNodes.
+                    val spliceResult = WorkflowUtils.spliceInstructions(
+                      instructionsToSplice,
+                      optimizedInstructions,
+                      Map(spliceEndpoint -> oldIndexToNewIndex(inputIndices.head),
+                        Pipeline.SOURCE -> oldIndexToNewIndex(tInputs.head)),
+                      spliceEndpoint)
+                    optimizedInstructions = spliceResult._1
+                    oldIndexToNewIndex = oldIndexToNewIndex andThen spliceResult._2
+                  }
+
+                  case _ => Unit
                 }
-
-                case _ => Unit
               }
-
               oe
             case EstimatorOutput(oe: OptimizableLabelEstimator[a, b, l]) =>
-              oe.optimize(inputs(0).asInstanceOf[RDD[a]], inputs(1).asInstanceOf[RDD[l]], numPerPartition.get)
-              val dataSpliceEndpoint = Pipeline.SOURCE - 1
-              val labelSpliceEndpoint = Pipeline.SOURCE - 2
-              val spliceEndpoint = Pipeline.SOURCE - 3
+              if (instructionsToOptimize.contains(index)) {
 
-              // Get the instructions to splice into the optimized pipeline
-              val dataSample = inputs(0).asInstanceOf[RDD[a]]
-              val labelSample = inputs(1).asInstanceOf[RDD[l]]
-              val pipeToSplice = oe.optimize(dataSample, labelSample, numPerPartition.get)
-                .apply(dataSample, labelSample)
-              val initialInstructionsToSplice = WorkflowUtils.pipelineToInstructions(pipeToSplice)
-              val dataSampleIndices = initialInstructionsToSplice.indices.filter {
-                initialInstructionsToSplice(_) == SourceNode(dataSample)
-              }.toSet
-              val labelSampleIndices = initialInstructionsToSplice.indices.filter {
-                initialInstructionsToSplice(_) == SourceNode(labelSample)
-              }.toSet
-              val instructionsToSplice = WorkflowUtils.disconnectAndRemoveInstructions(
-                dataSampleIndices.map(_ -> dataSpliceEndpoint).toMap ++
-                  labelSampleIndices.map(_ -> labelSpliceEndpoint).toMap,
-                initialInstructionsToSplice
-              )._1
+                oe.optimize(inputs(0).asInstanceOf[RDD[a]], inputs(1).asInstanceOf[RDD[l]], numPerPartition.get)
+                val dataSpliceEndpoint = Pipeline.SOURCE - 1
+                val labelSpliceEndpoint = Pipeline.SOURCE - 2
+                val spliceEndpoint = Pipeline.SOURCE - 3
 
-              // First: Disconnect all the dependencies in the optimized pipeline on this EstimatorFitNode,
-              // and remove this node
-              val indexInNewPipeline = oldIndexToNewIndex(index)
-              val removeResult = WorkflowUtils.disconnectAndRemoveInstructions(
-                Map(indexInNewPipeline -> (labelSpliceEndpoint - 1)),
-                optimizedInstructions)
-              optimizedInstructions = removeResult._1
-              oldIndexToNewIndex = oldIndexToNewIndex andThen removeResult._2
+                // Get the instructions to splice into the optimized pipeline
+                val dataSample = inputs(0).asInstanceOf[RDD[a]]
+                val labelSample = inputs(1).asInstanceOf[RDD[l]]
+                val pipeToSplice = oe.optimize(dataSample, labelSample, numPerPartition.get)
+                  .apply(dataSample, labelSample)
+                val initialInstructionsToSplice = WorkflowUtils.pipelineToInstructions(pipeToSplice)
+                val dataSampleIndices = initialInstructionsToSplice.indices.filter {
+                  initialInstructionsToSplice(_) == SourceNode(dataSample)
+                }.toSet
+                val labelSampleIndices = initialInstructionsToSplice.indices.filter {
+                  initialInstructionsToSplice(_) == SourceNode(labelSample)
+                }.toSet
+                val instructionsToSplice = WorkflowUtils.disconnectAndRemoveInstructions(
+                  dataSampleIndices.map(_ -> dataSpliceEndpoint).toMap ++
+                    labelSampleIndices.map(_ -> labelSpliceEndpoint).toMap,
+                  initialInstructionsToSplice
+                )._1
 
-              instructions.zipWithIndex.foreach {
-                case (TransformerApplyNode(t, tInputs), transformerApplyIndex) if t == index => {
-                  // First: Disconnect all the dependencies in the optimized pipeline on this TransformerApplyNode,
-                  // and replace them with the spliceEndpoint
+                // First: Disconnect all the dependencies in the optimized pipeline on this EstimatorFitNode,
+                // and remove this node
+                val indexInNewPipeline = oldIndexToNewIndex(index)
+                val removeResult = WorkflowUtils.disconnectAndRemoveInstructions(
+                  Map(indexInNewPipeline -> (labelSpliceEndpoint - 1)),
+                  optimizedInstructions)
+                optimizedInstructions = removeResult._1
+                oldIndexToNewIndex = oldIndexToNewIndex andThen removeResult._2
 
-                  val indexInNewPipeline = oldIndexToNewIndex(transformerApplyIndex)
-                  val removeResult = WorkflowUtils.disconnectAndRemoveInstructions(
-                    Map(indexInNewPipeline -> spliceEndpoint),
-                    optimizedInstructions)
-                  optimizedInstructions = removeResult._1
-                  oldIndexToNewIndex = oldIndexToNewIndex andThen removeResult._2
+                instructions.zipWithIndex.foreach {
+                  case (TransformerApplyNode(t, tInputs), transformerApplyIndex) if t == index => {
+                    // First: Disconnect all the dependencies in the optimized pipeline on this TransformerApplyNode,
+                    // and replace them with the spliceEndpoint
 
-                  // Then: Splice in the transformer's optimization into the optimized pipeline
-                  // Note: We do not delete the optimizable transformer because it may be used elsewhere
-                  // if we've merged equivalent TransformerNodes.
-                  val spliceResult = WorkflowUtils.spliceInstructions(
-                    instructionsToSplice,
-                    optimizedInstructions,
-                    Map(
-                      dataSpliceEndpoint -> oldIndexToNewIndex(inputIndices(0)),
-                      labelSpliceEndpoint -> oldIndexToNewIndex(inputIndices(1)),
-                      Pipeline.SOURCE -> oldIndexToNewIndex(tInputs.head)
-                    ),
-                    spliceEndpoint)
-                  optimizedInstructions = spliceResult._1
-                  oldIndexToNewIndex = oldIndexToNewIndex andThen spliceResult._2
+                    val indexInNewPipeline = oldIndexToNewIndex(transformerApplyIndex)
+                    val removeResult = WorkflowUtils.disconnectAndRemoveInstructions(
+                      Map(indexInNewPipeline -> spliceEndpoint),
+                      optimizedInstructions)
+                    optimizedInstructions = removeResult._1
+                    oldIndexToNewIndex = oldIndexToNewIndex andThen removeResult._2
+
+                    // Then: Splice in the transformer's optimization into the optimized pipeline
+                    // Note: We do not delete the optimizable transformer because it may be used elsewhere
+                    // if we've merged equivalent TransformerNodes.
+                    val spliceResult = WorkflowUtils.spliceInstructions(
+                      instructionsToSplice,
+                      optimizedInstructions,
+                      Map(
+                        dataSpliceEndpoint -> oldIndexToNewIndex(inputIndices(0)),
+                        labelSpliceEndpoint -> oldIndexToNewIndex(inputIndices(1)),
+                        Pipeline.SOURCE -> oldIndexToNewIndex(tInputs.head)
+                      ),
+                      spliceEndpoint)
+                    optimizedInstructions = spliceResult._1
+                    oldIndexToNewIndex = oldIndexToNewIndex andThen spliceResult._2
+                  }
+
+                  case _ => Unit
                 }
-
-                case _ => Unit
               }
-
               oe
             case EstimatorOutput(e) => e
             case _ => throw new ClassCastException("EstimatorFitNode dep wasn't pointing at an estimator")
           }
 
-          registers(index) = TransformerOutput(estimator.fitRDDs(inputs))
-          numPerPartitionPerNode(index) = numPerPartition
+          if (instructionsToExecute.contains(index)) {
+            registers(index) = TransformerOutput(estimator.fitRDDs(inputs))
+            numPerPartitionPerNode(index) = numPerPartition
+          }
         }
 
         case node: Instruction => {

--- a/src/main/scala/workflow/NodeOptimizationRule.scala
+++ b/src/main/scala/workflow/NodeOptimizationRule.scala
@@ -37,101 +37,195 @@ class NodeOptimizationRule(sampleFraction: Double = 0.01, seed: Long = 0) extend
     val registers = new Array[InstructionOutput](instructions.length)
     val numPerPartitionPerNode = Array.fill[Option[Map[Int, Int]]](instructions.length)(None)
 
-    for ((instruction, index) <- instructions.zipWithIndex) {
-      if (instructionsToExecute.contains(index)) {
-        instruction match {
-          case SourceNode(rdd) => {
-            val sampledRDD = rdd.sample(withReplacement = false, sampleFraction, seed)
-            registers(index) = RDDOutput(sampledRDD)
-            numPerPartitionPerNode(index) = Some(WorkflowUtils.numPerPartition(rdd))
+    for ((instruction, index) <- instructions.zipWithIndex if instructionsToExecute.contains(index)) {
+      instruction match {
+        case SourceNode(rdd) => {
+          val sampledRDD = rdd.sample(withReplacement = false, sampleFraction, seed)
+          registers(index) = RDDOutput(sampledRDD)
+          numPerPartitionPerNode(index) = Some(WorkflowUtils.numPerPartition(rdd))
+        }
+
+        case TransformerApplyNode(tIndex, inputIndices) => {
+          val numPerPartition = numPerPartitionPerNode(inputIndices.head)
+          val inputs = inputIndices.map(registers).collect {
+            case RDDOutput(rdd) => rdd.cache()
+          }
+          inputs.foreach(_.count())
+
+          // Optimize the transformer if possible
+          val transformer = registers(tIndex) match {
+            case TransformerOutput(ot: OptimizableTransformer[a, b]) =>
+              val pipeToSplice = ot.optimize(inputs.head.asInstanceOf[RDD[a]], numPerPartition.get)
+              val instructionsToSplice = WorkflowUtils.pipelineToInstructions(pipeToSplice)
+
+              // First: Disconnect all the dependencies in the optimized pipeline on this TransformerApplyNode,
+              // and replace them with the spliceEndpoint
+              val spliceEndpoint = Pipeline.SOURCE - 1
+              val indexInNewPipeline = oldIndexToNewIndex(index)
+              val removeResult = WorkflowUtils.disconnectAndRemoveInstructions(
+                Map(indexInNewPipeline -> spliceEndpoint),
+                optimizedInstructions)
+              optimizedInstructions = removeResult._1
+              oldIndexToNewIndex = oldIndexToNewIndex andThen removeResult._2
+
+              // Then: Splice in the transformer's optimization into the optimized pipeline
+              // Note: We do not delete the optimizable transformer because it may be used elsewhere
+              // if we've merged equivalent TransformerNodes.
+              val spliceResult = WorkflowUtils.spliceInstructions(
+                instructionsToSplice,
+                optimizedInstructions,
+                Map(Pipeline.SOURCE -> oldIndexToNewIndex(inputIndices.head)),
+                spliceEndpoint)
+              optimizedInstructions = spliceResult._1
+              oldIndexToNewIndex = oldIndexToNewIndex andThen spliceResult._2
+
+              ot
+            case TransformerOutput(t) => t
+            case _ => throw new ClassCastException("TransformerApplyNode dep wasn't pointing at a transformer")
           }
 
-          case TransformerApplyNode(tIndex, inputIndices) => {
-            val numPerPartition = numPerPartitionPerNode(inputIndices.head)
-            val inputs = inputIndices.map(registers).collect {
-              case RDDOutput(rdd) => rdd.cache()
-            }
-            inputs.foreach(_.count())
+          registers(index) = RDDOutput(transformer.transformRDD(inputs))
+          numPerPartitionPerNode(index) = numPerPartition
+        }
 
-            // Optimize the transformer if possible
-            val transformer = registers(tIndex) match {
-              case TransformerOutput(ot: OptimizableTransformer[a, b]) =>
-                val pipeToSplice = ot.optimize(inputs.head.asInstanceOf[RDD[a]], numPerPartition.get)
-                val instructionsToSplice = WorkflowUtils.pipelineToInstructions(pipeToSplice)
+        case EstimatorFitNode(estIndex, inputIndices) => {
+          val numPerPartition = numPerPartitionPerNode(inputIndices.head)
+          val inputs = inputIndices.map(registers).collect {
+            case RDDOutput(rdd) => rdd.cache()
+          }
+          inputs.foreach(_.count())
 
-                // First: Disconnect all the dependencies in the optimized pipeline on this TransformerApplyNode
-                val spliceEndpoint = Pipeline.SOURCE - 1
-                val indexInNewPipeline = oldIndexToNewIndex(index)
-                optimizedInstructions = optimizedInstructions.map(_.mapDependencies {
-                  i => if (i == indexInNewPipeline) spliceEndpoint else i
-                })
+          // Optimize the estimator if possible
+          val estimator = registers(estIndex) match {
+            case EstimatorOutput(oe: OptimizableEstimator[a, b]) =>
+              val spliceEndpoint = Pipeline.SOURCE - 1
 
-                // Next: Remove this TransformerApplyNode from the optimized pipeline
-                val removeResult = WorkflowUtils.removeInstructions(Set(indexInNewPipeline), optimizedInstructions)
-                optimizedInstructions = removeResult._1
-                oldIndexToNewIndex = oldIndexToNewIndex andThen removeResult._2
+              // Get the instructions to splice into the optimized pipeline
+              val dataSample = inputs.head.asInstanceOf[RDD[a]]
+              val pipeToSplice = oe.optimize(dataSample, numPerPartition.get).apply(dataSample)
+              val initialInstructionsToSplice = WorkflowUtils.pipelineToInstructions(pipeToSplice)
+              val dataSampleIndices = initialInstructionsToSplice.indices.filter {
+                initialInstructionsToSplice(_) == SourceNode(dataSample)
+              }.toSet
+              val instructionsToSplice = WorkflowUtils.disconnectAndRemoveInstructions(
+                dataSampleIndices.map(_ -> spliceEndpoint).toMap,
+                initialInstructionsToSplice
+              )._1
 
-                // Finally: Splice in the transformer's optimization into the optimized pipeline
-                // Note: We do not delete the optimizable transformer because it may be used elsewhere
-                // if we've merged equivalent TransformerNodes.
-                val spliceResult = WorkflowUtils.spliceInstructions(
-                  instructionsToSplice,
-                  optimizedInstructions,
-                  Map(Pipeline.SOURCE -> oldIndexToNewIndex(inputIndices.head)),
-                  spliceEndpoint)
-                optimizedInstructions = spliceResult._1
-                oldIndexToNewIndex = oldIndexToNewIndex andThen spliceResult._2
+              // First: Disconnect all the dependencies in the optimized pipeline on this EstimatorFitNode,
+              // and remove this node
+              val indexInNewPipeline = oldIndexToNewIndex(index)
+              val removeResult = WorkflowUtils.disconnectAndRemoveInstructions(
+                Map(indexInNewPipeline -> (spliceEndpoint - 1)),
+                optimizedInstructions)
+              optimizedInstructions = removeResult._1
+              oldIndexToNewIndex = oldIndexToNewIndex andThen removeResult._2
 
-                ot
-              case TransformerOutput(t) => t
-              case _ => throw new ClassCastException("TransformerApplyNode dep wasn't pointing at a transformer")
-            }
+              instructions.zipWithIndex.foreach {
+                case (TransformerApplyNode(t, tInputs), transformerApplyIndex) if t == index => {
+                  // First: Disconnect all the dependencies in the optimized pipeline on this TransformerApplyNode,
+                  // and replace them with the spliceEndpoint
 
-            registers(index) = RDDOutput(transformer.transformRDD(inputs))
-            numPerPartitionPerNode(index) = numPerPartition
+                  val indexInNewPipeline = oldIndexToNewIndex(transformerApplyIndex)
+                  val removeResult = WorkflowUtils.disconnectAndRemoveInstructions(
+                    Map(indexInNewPipeline -> spliceEndpoint),
+                    optimizedInstructions)
+                  optimizedInstructions = removeResult._1
+                  oldIndexToNewIndex = oldIndexToNewIndex andThen removeResult._2
+
+                  // Then: Splice in the transformer's optimization into the optimized pipeline
+                  // Note: We do not delete the optimizable transformer because it may be used elsewhere
+                  // if we've merged equivalent TransformerNodes.
+                  val spliceResult = WorkflowUtils.spliceInstructions(
+                    instructionsToSplice,
+                    optimizedInstructions,
+                    Map(spliceEndpoint -> oldIndexToNewIndex(inputIndices.head),
+                      Pipeline.SOURCE -> oldIndexToNewIndex(tInputs.head)),
+                    spliceEndpoint)
+                  optimizedInstructions = spliceResult._1
+                  oldIndexToNewIndex = oldIndexToNewIndex andThen spliceResult._2
+                }
+
+                case _ => Unit
+              }
+
+              oe
+            case EstimatorOutput(oe: OptimizableLabelEstimator[a, b, l]) =>
+              oe.optimize(inputs(0).asInstanceOf[RDD[a]], inputs(1).asInstanceOf[RDD[l]], numPerPartition.get)
+              val dataSpliceEndpoint = Pipeline.SOURCE - 1
+              val labelSpliceEndpoint = Pipeline.SOURCE - 2
+              val spliceEndpoint = Pipeline.SOURCE - 3
+
+              // Get the instructions to splice into the optimized pipeline
+              val dataSample = inputs(0).asInstanceOf[RDD[a]]
+              val labelSample = inputs(1).asInstanceOf[RDD[l]]
+              val pipeToSplice = oe.optimize(dataSample, labelSample, numPerPartition.get)
+                .apply(dataSample, labelSample)
+              val initialInstructionsToSplice = WorkflowUtils.pipelineToInstructions(pipeToSplice)
+              val dataSampleIndices = initialInstructionsToSplice.indices.filter {
+                initialInstructionsToSplice(_) == SourceNode(dataSample)
+              }.toSet
+              val labelSampleIndices = initialInstructionsToSplice.indices.filter {
+                initialInstructionsToSplice(_) == SourceNode(labelSample)
+              }.toSet
+              val instructionsToSplice = WorkflowUtils.disconnectAndRemoveInstructions(
+                dataSampleIndices.map(_ -> dataSpliceEndpoint).toMap ++
+                  labelSampleIndices.map(_ -> labelSpliceEndpoint).toMap,
+                initialInstructionsToSplice
+              )._1
+
+              // First: Disconnect all the dependencies in the optimized pipeline on this EstimatorFitNode,
+              // and remove this node
+              val indexInNewPipeline = oldIndexToNewIndex(index)
+              val removeResult = WorkflowUtils.disconnectAndRemoveInstructions(
+                Map(indexInNewPipeline -> (labelSpliceEndpoint - 1)),
+                optimizedInstructions)
+              optimizedInstructions = removeResult._1
+              oldIndexToNewIndex = oldIndexToNewIndex andThen removeResult._2
+
+              instructions.zipWithIndex.foreach {
+                case (TransformerApplyNode(t, tInputs), transformerApplyIndex) if t == index => {
+                  // First: Disconnect all the dependencies in the optimized pipeline on this TransformerApplyNode,
+                  // and replace them with the spliceEndpoint
+
+                  val indexInNewPipeline = oldIndexToNewIndex(transformerApplyIndex)
+                  val removeResult = WorkflowUtils.disconnectAndRemoveInstructions(
+                    Map(indexInNewPipeline -> spliceEndpoint),
+                    optimizedInstructions)
+                  optimizedInstructions = removeResult._1
+                  oldIndexToNewIndex = oldIndexToNewIndex andThen removeResult._2
+
+                  // Then: Splice in the transformer's optimization into the optimized pipeline
+                  // Note: We do not delete the optimizable transformer because it may be used elsewhere
+                  // if we've merged equivalent TransformerNodes.
+                  val spliceResult = WorkflowUtils.spliceInstructions(
+                    instructionsToSplice,
+                    optimizedInstructions,
+                    Map(
+                      dataSpliceEndpoint -> oldIndexToNewIndex(inputIndices(0)),
+                      labelSpliceEndpoint -> oldIndexToNewIndex(inputIndices(1)),
+                      Pipeline.SOURCE -> oldIndexToNewIndex(tInputs.head)
+                    ),
+                    spliceEndpoint)
+                  optimizedInstructions = spliceResult._1
+                  oldIndexToNewIndex = oldIndexToNewIndex andThen spliceResult._2
+                }
+
+                case _ => Unit
+              }
+
+              oe
+            case EstimatorOutput(e) => e
+            case _ => throw new ClassCastException("EstimatorFitNode dep wasn't pointing at an estimator")
           }
 
-          case EstimatorFitNode(estIndex, inputIndices) => {
-            val numPerPartition = numPerPartitionPerNode(inputIndices.head)
-            val inputs = inputIndices.map(registers).collect {
-              case RDDOutput(rdd) => rdd.cache()
-            }
-            inputs.foreach(_.count())
+          registers(index) = TransformerOutput(estimator.fitRDDs(inputs))
+          numPerPartitionPerNode(index) = numPerPartition
+        }
 
-            // Optimize the estimator if possible
-            val estimator = registers(estIndex) match {
-              case EstimatorOutput(oe: OptimizableEstimator[a, b]) =>
-                // Get the instructions to splice into the optimized pipeline
-                val dataSample = inputs.head.asInstanceOf[RDD[a]]
-                val pipeToSplice = oe.optimize(dataSample, numPerPartition.get).apply(dataSample)
-                val initialInstructionsToSplice = WorkflowUtils.pipelineToInstructions(pipeToSplice)
-                val dataSampleIndices = initialInstructionsToSplice.indices.filter {
-                  initialInstructionsToSplice(_) == SourceNode(dataSample)
-                }.toSet
-                val instructionsToSplice = WorkflowUtils.removeInstructions(dataSampleIndices,
-                  initialInstructionsToSplice.map(_.mapDependencies {
-                    i => if (dataSampleIndices.contains(i)) Pipeline.SOURCE - 1 else i
-                  }))
-
-                // Get the set of nodes depending on this estimator fit node,
-                // and disconnect them from it
-
-                oe
-              case EstimatorOutput(oe: OptimizableLabelEstimator[a, b, l]) =>
-                oe.optimize(inputs(0).asInstanceOf[RDD[a]], inputs(1).asInstanceOf[RDD[l]], numPerPartition.get)
-                oe
-              case EstimatorOutput(e) => e
-              case _ => throw new ClassCastException("EstimatorFitNode dep wasn't pointing at an estimator")
-            }
-
-            registers(index) = TransformerOutput(estimator.fitRDDs(inputs))
-            numPerPartitionPerNode(index) = numPerPartition
-          }
-
-          case node: Instruction => {
-            val deps = node.getDependencies.map(registers)
-            registers(index) = node.execute(deps)
-          }
+        case node: Instruction => {
+          val deps = node.getDependencies.map(registers)
+          registers(index) = node.execute(deps)
         }
       }
     }

--- a/src/main/scala/workflow/OptimizableNodes.scala
+++ b/src/main/scala/workflow/OptimizableNodes.scala
@@ -12,7 +12,7 @@ abstract class OptimizableTransformer[A, B : ClassTag] extends Transformer[A, B]
   override def apply(a: A) = default.apply(a)
   override def apply(data: RDD[A]) = default.apply(data)
 
-  def optimize(sample: RDD[A], numPerPartition: Map[Int, Int]): Transformer[A, B]
+  def optimize(sample: RDD[A], numPerPartition: Map[Int, Int]): Pipeline[A, B]
 }
 
 /**
@@ -25,7 +25,7 @@ abstract class OptimizableEstimator[A, B] extends Estimator[A, B] {
   // Due to some crazy Scala compiler shenanigans we need to do this roundabout fitRDDs call thing.
   override def fit(data: RDD[A]): Transformer[A, B] = default.fitRDDs(Seq(data)).asInstanceOf[Transformer[A, B]]
 
-  def optimize(sample: RDD[A], numPerPartition: Map[Int, Int]): Estimator[A, B]
+  def optimize(sample: RDD[A], numPerPartition: Map[Int, Int]): RDD[A] => Pipeline[A, B]
 }
 
 /**
@@ -40,5 +40,5 @@ abstract class OptimizableLabelEstimator[A, B, L] extends LabelEstimator[A, B, L
     default.fitRDDs(Seq(data, labels)).asInstanceOf[Transformer[A, B]]
   }
 
-  def optimize(sample: RDD[A], sampleLabels: RDD[L], numPerPartition: Map[Int, Int]): LabelEstimator[A, B, L]
+  def optimize(sample: RDD[A], sampleLabels: RDD[L], numPerPartition: Map[Int, Int]): (RDD[A], RDD[L]) => Pipeline[A, B]
 }

--- a/src/main/scala/workflow/WorkflowUtils.scala
+++ b/src/main/scala/workflow/WorkflowUtils.scala
@@ -192,6 +192,19 @@ object WorkflowUtils {
     (newInstructions, oldToNewIndexMapping)
   }
 
+  /**
+   * This method first replaces all dependencies on specific instructions with a different int, effectively
+   * disconnecting them from the pipeline. It then removes the disconnected instructions from the pipeline.
+   *
+   * It is useful if you want to replace a section of the pipeline, by disconnecting and removing a section,
+   * and setting endpoints to use for splicing in new instructions.
+   *
+   * @param dependencyReplacement A map of (instruction index to remove) to
+   *                              (int to be swapped in for all previous dependencies on it)
+   * @param instructions The pipeline to remove from.
+   * @return A tuple containing the new instructions, and
+   *         a mapping of old dependency index to new dependency index
+   */
   def disconnectAndRemoveInstructions(dependencyReplacement: Map[Int, Int], instructions: Seq[Instruction])
   : (Seq[Instruction], Int => Int) = {
     val removeResult = removeInstructions(dependencyReplacement.keys.toSet, instructions.map(_.mapDependencies {

--- a/src/test/scala/workflow/NodeOptimizationRuleSuite.scala
+++ b/src/test/scala/workflow/NodeOptimizationRuleSuite.scala
@@ -128,11 +128,11 @@ object NodeOptimizationRuleSuite {
   }
   val optimizableEstimator = new OptimizableEstimator[State, State] {
     override val default: Estimator[State, State] = estimatorDoNothing
-    override def optimize(sample: RDD[State], numPerPartition: Map[Int, Int]): Estimator[State, State] = {
+    override def optimize(sample: RDD[State], numPerPartition: Map[Int, Int]): RDD[State] => Pipeline[State, State] = {
       if (sample.collect().exists(_.choice.get == false)) {
-        estimatorA
+        estimatorA.withData
       } else {
-        estimatorB
+        estimatorB.withData
       }
     }
   }
@@ -150,16 +150,16 @@ object NodeOptimizationRuleSuite {
   val optimizableLabelEstimator = new OptimizableLabelEstimator[State, State, Boolean] {
     override val default: LabelEstimator[State, State, Boolean] = labelEstimatorDoNothing
     override def optimize(sample: RDD[State], sampleLabels: RDD[Boolean], numPerPartition: Map[Int, Int])
-    : LabelEstimator[State, State, Boolean] = {
+    : (RDD[State], RDD[Boolean]) => Pipeline[State, State] = {
       // Test to make sure the zipping worked correctly
       sample.zip(sampleLabels).foreach { x =>
         assert(x._1.choice.get == x._2, "Label and choice must be equal!")
       }
 
       if (sample.collect().exists(_.choice.get == false)) {
-        labelEstimatorA
+        labelEstimatorA.withData
       } else {
-        labelEstimatorB
+        labelEstimatorB.withData
       }
     }
   }

--- a/src/test/scala/workflow/NodeOptimizationRuleSuite.scala
+++ b/src/test/scala/workflow/NodeOptimizationRuleSuite.scala
@@ -100,7 +100,7 @@ object NodeOptimizationRuleSuite {
   )
 
   val transformerDoNothing = Transformer[State, State] { x =>
-    assert(x.choice.isEmpty, "The default transformer must only be used on test data")
+    //assert(x.choice.isEmpty, "The default transformer must only be used on test data")
     x.copy(transformerChoice = None)
   }
   val transformerA = Transformer[State, State](_.copy(transformerChoice = Some(false)))

--- a/src/test/scala/workflow/NodeOptimizationRuleSuite.scala
+++ b/src/test/scala/workflow/NodeOptimizationRuleSuite.scala
@@ -100,7 +100,6 @@ object NodeOptimizationRuleSuite {
   )
 
   val transformerDoNothing = Transformer[State, State] { x =>
-    //assert(x.choice.isEmpty, "The default transformer must only be used on test data")
     x.copy(transformerChoice = None)
   }
   val transformerA = Transformer[State, State](_.copy(transformerChoice = Some(false)))

--- a/src/test/scala/workflow/NodeOptimizationRuleSuite.scala
+++ b/src/test/scala/workflow/NodeOptimizationRuleSuite.scala
@@ -24,7 +24,7 @@ class NodeOptimizationRuleSuite extends FunSuite with LocalSparkContext with Log
       (optimizableEstimator, trainData) andThen
       (optimizableLabelEstimator, trainData, trainLabels)
 
-    val nodeOptimizedPipeline = new NodeOptimizationRule(0.01).apply(pipeline)
+    val nodeOptimizedPipeline = new NodeOptimizationRule().apply(pipeline)
     val outputState = nodeOptimizedPipeline.apply(State(), optimizer = None)
 
     assert(outputState.transformerChoice.isEmpty, "The optimizable transformer should use the default on test data")
@@ -45,7 +45,7 @@ class NodeOptimizationRuleSuite extends FunSuite with LocalSparkContext with Log
       (optimizableEstimator, trainData) andThen
       (optimizableLabelEstimator, trainData, trainLabels)
 
-    val nodeOptimizedPipeline = new NodeOptimizationRule(0.01).apply(pipeline)
+    val nodeOptimizedPipeline = new NodeOptimizationRule().apply(pipeline)
     val outputState = nodeOptimizedPipeline.apply(State(), optimizer = None)
 
     assert(outputState.transformerChoice.isEmpty, "The optimizable transformer should use the default on test data")
@@ -66,7 +66,7 @@ class NodeOptimizationRuleSuite extends FunSuite with LocalSparkContext with Log
       (estimatorB, trainData) andThen
       (labelEstimatorB, trainData, trainLabels)
 
-    val nodeOptimizedPipeline = new NodeOptimizationRule(0.01).apply(pipeline)
+    val nodeOptimizedPipeline = new NodeOptimizationRule().apply(pipeline)
     val outputState = nodeOptimizedPipeline.apply(State(), optimizer = None)
 
     assert(outputState === State(None, Some(false), Some(true), Some(true)))
@@ -84,7 +84,7 @@ class NodeOptimizationRuleSuite extends FunSuite with LocalSparkContext with Log
       (estimatorB, trainData) andThen
       (optimizableLabelEstimator, trainData, trainLabels)
 
-    val nodeOptimizedPipeline = new NodeOptimizationRule(0.01).apply(pipeline)
+    val nodeOptimizedPipeline = new NodeOptimizationRule().apply(pipeline)
     val outputState = nodeOptimizedPipeline.apply(State(), optimizer = None)
 
     assert(outputState === State(None, Some(false), Some(true), Some(true)))

--- a/src/test/scala/workflow/WorkflowUtilsSuite.scala
+++ b/src/test/scala/workflow/WorkflowUtilsSuite.scala
@@ -6,51 +6,53 @@ import org.scalatest.FunSuite
 import pipelines.{LocalSparkContext, Logging}
 
 class WorkflowUtilsSuite extends FunSuite with LocalSparkContext with Logging {
+  val doubleTransformer = new Transformer[Int, Int] {
+    override def apply(in: Int): Int = in * 2
+    override val label = "x * 2"
+  }
+
+  val quadrupleTransformer = new Transformer[Int, Int] {
+    override def apply(in: Int): Int = in * 4
+    override val label = "x * 4"
+  }
+
+  val minusThreeTransformer = new Transformer[Int, Int] {
+    override def apply(in: Int): Int = in - 3
+    override val label = "x - 3"
+  }
+
+  val plusDataEstimator = new Estimator[Int, Int] {
+    protected def fit(data: RDD[Int]): Transformer[Int, Int] = {
+      val first = data.first()
+      Transformer(x => x + first)
+    }
+    override val label = "x + data.first()"
+  }
+
+  val identityEstimator = new Estimator[Int, Int] {
+    protected def fit(data: RDD[Int]): Transformer[Int, Int] = {
+      Transformer(x => x)
+    }
+    override val label = "x"
+  }
+
+  val plusDataPlusLabelEstimator = new LabelEstimator[Int, Int, String] {
+    protected def fit(data: RDD[Int], labels: RDD[String]): Transformer[Int, Int] = {
+      val first = data.first() + labels.first().toInt
+      Transformer(x => x + first)
+    }
+    override val label = "x + data.first() + label.first()"
+  }
+
   test("Pipeline to Instructions to Pipeline") {
     sc = new SparkContext("local", "test")
 
     val trainData = sc.parallelize(Seq(32, 94, 12))
 
-    val doubleTransformer = new Transformer[Int, Int] {
-      override def apply(in: Int): Int = in * 2
-      override val label = "x * 2"
-    }
-
-    val quadrupleTransformer = new Transformer[Int, Int] {
-      override def apply(in: Int): Int = in * 4
-      override val label = "x * 4"
-    }
-
-    val minusThreeTransformer = new Transformer[Int, Int] {
-      override def apply(in: Int): Int = in - 3
-      override val label = "x - 3"
-    }
-
     val firstPipeline = doubleTransformer andThen minusThreeTransformer
 
-    val plusDataEstimator = new Estimator[Int, Int] {
-      protected def fit(data: RDD[Int]): Transformer[Int, Int] = {
-        val first = data.first()
-        Transformer(x => x + first)
-      }
-      override val label = "x + data.first()"
-    }
     val secondPipeline = doubleTransformer andThen (plusDataEstimator, trainData)
 
-    val identityEstimator = new Estimator[Int, Int] {
-      protected def fit(data: RDD[Int]): Transformer[Int, Int] = {
-        Transformer(x => x)
-      }
-      override val label = "x"
-    }
-
-    val plusDataPlusLabelEstimator = new LabelEstimator[Int, Int, String] {
-      protected def fit(data: RDD[Int], labels: RDD[String]): Transformer[Int, Int] = {
-        val first = data.first() + labels.first().toInt
-        Transformer(x => x + first)
-      }
-      override val label = "x + data.first() + label.first()"
-    }
     val labelData = sc.parallelize(Seq("10", "7", "14"))
     val thirdPipeline = quadrupleTransformer andThen
       (identityEstimator, trainData) andThen
@@ -109,5 +111,149 @@ class WorkflowUtilsSuite extends FunSuite with LocalSparkContext with Logging {
       thirdPipeline.apply(x))
     }
     assert(pipeline(sc.parallelize(data)).collect().toSeq === correctOut)
+  }
+
+  test("Instruction removal test") {
+    sc = new SparkContext("local", "test")
+
+    val trainData = sc.parallelize(Seq(32, 94, 12))
+    val labelData = sc.parallelize(Seq("10", "7", "14"))
+
+    val pipelineInstructions = Seq(
+      doubleTransformer, // 0
+      TransformerApplyNode(0, Seq(Pipeline.SOURCE)), // 1
+      minusThreeTransformer, // 2
+      TransformerApplyNode(2, Seq(1)), // 3
+      SourceNode(trainData), // 4
+      doubleTransformer, // 5
+      TransformerApplyNode(5, Seq(4)), // 6
+      plusDataEstimator, // 7
+      doubleTransformer, // 8 - to remove
+      EstimatorFitNode(7, Seq(6)), // 9
+      TransformerApplyNode(9, Seq(1)), // 10
+      quadrupleTransformer, // 11
+      TransformerApplyNode(11, Seq(4)), // 12
+      identityEstimator, // 13
+      EstimatorFitNode(13, Seq(12)), // 14
+      TransformerApplyNode(14, Seq(12)), // 15
+      identityEstimator, // 16 - to remove
+      SourceNode(labelData), // 17
+      plusDataPlusLabelEstimator, // 18
+      EstimatorFitNode(18, Seq(15, 17)), // 19
+      quadrupleTransformer, // 20
+      TransformerApplyNode(20, Seq(Pipeline.SOURCE)), // 21
+      TransformerApplyNode(14, Seq(21)), // 22
+      TransformerApplyNode(19, Seq(22)), // 23
+      GatherTransformer(), // 24
+      TransformerApplyNode(24, Seq(3, 10, 23)) // 25
+    )
+
+    // Make sure dependency breaking throws an exception
+    intercept[RuntimeException] {
+      WorkflowUtils.removeInstructions(Set(7, 12), pipelineInstructions)
+    }
+
+    val instructionsRemoved = WorkflowUtils.removeInstructions(Set(8, 16), pipelineInstructions)._1
+
+    assert(instructionsRemoved === Seq(
+      doubleTransformer, // 0
+      TransformerApplyNode(0, Seq(Pipeline.SOURCE)), // 1
+      minusThreeTransformer, // 2
+      TransformerApplyNode(2, Seq(1)), // 3
+      SourceNode(trainData), // 4
+      doubleTransformer, // 5
+      TransformerApplyNode(5, Seq(4)), // 6
+      plusDataEstimator, // 7
+      EstimatorFitNode(7, Seq(6)), // 8
+      TransformerApplyNode(8, Seq(1)), // 9
+      quadrupleTransformer, // 10
+      TransformerApplyNode(10, Seq(4)), // 11
+      identityEstimator, // 12
+      EstimatorFitNode(12, Seq(11)), // 13
+      TransformerApplyNode(13, Seq(11)), // 14
+      SourceNode(labelData), // 15
+      plusDataPlusLabelEstimator, // 16
+      EstimatorFitNode(16, Seq(14, 15)), // 17
+      quadrupleTransformer, // 18
+      TransformerApplyNode(18, Seq(Pipeline.SOURCE)), // 19
+      TransformerApplyNode(13, Seq(19)), // 20
+      TransformerApplyNode(17, Seq(20)), // 21
+      GatherTransformer(), // 22
+      TransformerApplyNode(22, Seq(3, 9, 21)) // 23
+    ))
+  }
+
+  test("Instruction splicing") {
+    sc = new SparkContext("local", "test")
+
+    val trainData = sc.parallelize(Seq(32, 94, 12))
+    val labelData = sc.parallelize(Seq("10", "7", "14"))
+
+    val pipelineInstructions = Seq(
+      doubleTransformer, // 0
+      TransformerApplyNode(0, Seq(Pipeline.SOURCE)), // 1
+      minusThreeTransformer, // 2
+      TransformerApplyNode(2, Seq(1)), // 3
+      SourceNode(trainData), // 4
+      doubleTransformer, // 5
+      TransformerApplyNode(5, Seq(4)), // 6
+      plusDataEstimator, // 7
+      EstimatorFitNode(7, Seq(6)), // 8
+      TransformerApplyNode(8, Seq(1)), // 9
+      quadrupleTransformer, // 10 - splice with another minusThreeTransformer
+      TransformerApplyNode(10, Seq(4)), // 11 - splice with an apply for the new doubleTransformer
+      identityEstimator, // 12
+      EstimatorFitNode(12, Seq(11)), // 13
+      TransformerApplyNode(13, Seq(11)), // 14
+      SourceNode(labelData), // 15
+      plusDataPlusLabelEstimator, // 16
+      EstimatorFitNode(16, Seq(14, 15)), // 17
+      quadrupleTransformer, // 18
+      TransformerApplyNode(18, Seq(Pipeline.SOURCE)), // 19
+      TransformerApplyNode(13, Seq(19)), // 20
+      TransformerApplyNode(17, Seq(20)), // 21
+      GatherTransformer(), // 22
+      TransformerApplyNode(22, Seq(3, 9, 21)) // 23
+    )
+
+    val splice = Seq(
+      minusThreeTransformer,
+      TransformerApplyNode(0, Seq(Pipeline.SOURCE))
+    )
+
+    val splicedInstructions = WorkflowUtils.spliceInstructions(
+      splice,
+      pipelineInstructions,
+      Map(Pipeline.SOURCE -> 4),
+      11)._1
+
+    assert(splicedInstructions === Seq(
+      doubleTransformer, // 0
+      TransformerApplyNode(0, Seq(Pipeline.SOURCE)), // 1
+      minusThreeTransformer, // 2
+      TransformerApplyNode(2, Seq(1)), // 3
+      SourceNode(trainData), // 4
+      minusThreeTransformer, // 5 - the instructions spliced in
+      TransformerApplyNode(5, Seq(4)), // 6 - the instructions spliced in
+      doubleTransformer, // 7
+      TransformerApplyNode(7, Seq(4)), // 8
+      plusDataEstimator, // 9
+      EstimatorFitNode(9, Seq(8)), // 10
+      TransformerApplyNode(10, Seq(1)), // 11
+      quadrupleTransformer, // 12 - a no longer used instruction
+      TransformerApplyNode(12, Seq(4)), // 13 - a no longer used instruction
+      identityEstimator, // 14
+      EstimatorFitNode(14, Seq(6)), // 15 - now points at the spliced instructions
+      TransformerApplyNode(15, Seq(6)), // 16 - now points at the spliced instructions
+      SourceNode(labelData), // 17
+      plusDataPlusLabelEstimator, // 18
+      EstimatorFitNode(18, Seq(16, 17)), // 19
+      quadrupleTransformer, // 20
+      TransformerApplyNode(20, Seq(Pipeline.SOURCE)), // 21
+      TransformerApplyNode(15, Seq(21)), // 22
+      TransformerApplyNode(19, Seq(22)), // 23
+      GatherTransformer(), // 24
+      TransformerApplyNode(24, Seq(3, 11, 23)) // 25
+    ))
   }
 }


### PR DESCRIPTION
Allows node-level optimization rules to construct pipelines instead of just returning a single node.

The code in it's current form is very convoluted but the unit tests pass. Suggestions for how to improve it would be appreciated.