### PR TITLE
Replace LLH computation with a while loop

### DIFF
--- a/src/main/scala/nodes/learning/GaussianMixtureModelEstimator.scala
+++ b/src/main/scala/nodes/learning/GaussianMixtureModelEstimator.scala
@@ -110,10 +110,8 @@ case class GaussianMixtureModelEstimator(
     while ((iter < maxIterations) && costImproving && largeEnoughClusters) {
       /* E-STEP */
 
-      /*
-      compute the squared malhanobis distance for each gaussian.
-      sq_mal_dist(i,j) || x_i - mu_j||_Lambda^2.
-      */
+      // compute the squared malhanobis distance for each gaussian.
+      // sq_mal_dist(i,j) || x_i - mu_j||_Lambda^2.
       val sqMahlist = (XSq * gmmVars.map(0.5 / _).t) - (X * (gmmMeans :/ gmmVars).t) +
           (DenseMatrix.ones[Double](numSamples, 1) * (sum(gmmMeans :* gmmMeans :/ gmmVars, Axis._1).t :* 0.5))
 
@@ -122,25 +120,31 @@ case class GaussianMixtureModelEstimator(
           (-0.5 * numFeatures * math.log(2 * math.Pi) - 0.5 * sum(bLog(gmmVars), Axis._1).t + bLog(gmmWeights)) -
           sqMahlist
 
-      /*
-      compute the log likelihood of the model using the incremental
-      approach suggested by the Xerox folks.  The key thing here is that
-      for all intents and purposes, log(1+exp(t)) is equal to zero is t<-30
-      and equal to t if t>30
-      */
-      var lseLLH = llh(::, 0)
+      // compute the log likelihood of the model using the incremental
+      // approach suggested by the Xerox folks.  The key thing here is that
+      // for all intents and purposes, log(1+exp(t)) is equal to zero is t<-30
+      // and equal to t if t>30
+      val lseLLH = llh(::, 0).copy
       var cluster = 1
       while (cluster < k) {
-        val deltaLSE = lseLLH - llh(::, cluster)
-        val deltaLSEThreshold = min(max(deltaLSE, -30.0), 30.0)
-        val lseIncrement = (deltaLSE.map(x => if (x > 30.0) 1.0 else 0.0) :* deltaLSE) + (
-            deltaLSE.map(x => if (x > -30.0) 1.0 else 0.0) :*
-            deltaLSE.map(x => if (x <= 30.0) 1.0 else 0.0) :*
-            bLog(exp(deltaLSEThreshold) + 1.0)
-        )
-        lseLLH = llh(::, cluster) + lseIncrement
+        var sample = 0
+        // Extract this cluster's llh as a vector
+        val llhCluster = llh(::, cluster)
+        while (sample < numSamples) {
+          val deltaLSE = lseLLH(sample) - llhCluster(sample)
+          var lseIncrement = 0.0
+          if (deltaLSE > 30.0) {
+            lseIncrement = deltaLSE
+          } else if (deltaLSE > -30.0) {
+            val deltaLSEThreshold = min(max(deltaLSE, -30.0), 30.0)
+            lseIncrement = bLog(exp(deltaLSEThreshold) + 1.0)
+          } // else t < -30 which adds no weight
+          lseLLH(sample) = lseIncrement + llhCluster(sample)
+          sample = sample + 1
+        }
         cluster += 1
       }
+
       curCost(iter) = mean(lseLLH)
       logInfo(s"iter=$iter, llh=${curCost(iter)}")
       // Check if we're making progress

--- a/src/main/scala/nodes/learning/GaussianMixtureModelEstimator.scala
+++ b/src/main/scala/nodes/learning/GaussianMixtureModelEstimator.scala
@@ -113,7 +113,7 @@ case class GaussianMixtureModelEstimator(
       // compute the squared malhanobis distance for each gaussian.
       // sq_mal_dist(i,j) || x_i - mu_j||_Lambda^2.
       val sqMahlist = (XSq * (0.5 :/ gmmVars).t) - (X * (gmmMeans :/ gmmVars).t)
-      sqMahlist(*, ::) += (sum(gmmMeans :* gmmMeans :/ gmmVars, Axis._1) :+ 0.5)
+      sqMahlist(*, ::) += (sum(gmmMeans :* gmmMeans :/ gmmVars, Axis._1) :* 0.5)
 
       // compute the log likelihood of the approximate posterior
       val llh = DenseMatrix.ones[Double](numSamples, 1) *

--- a/src/main/scala/nodes/learning/GaussianMixtureModelEstimator.scala
+++ b/src/main/scala/nodes/learning/GaussianMixtureModelEstimator.scala
@@ -112,8 +112,8 @@ case class GaussianMixtureModelEstimator(
 
       // compute the squared malhanobis distance for each gaussian.
       // sq_mal_dist(i,j) || x_i - mu_j||_Lambda^2.
-      val sqMahlist = (XSq * gmmVars.map(0.5 / _).t) - (X * (gmmMeans :/ gmmVars).t) +
-          (DenseMatrix.ones[Double](numSamples, 1) * (sum(gmmMeans :* gmmMeans :/ gmmVars, Axis._1).t :* 0.5))
+      val sqMahlist = (XSq * (0.5 :/ gmmVars).t) - (X * (gmmMeans :/ gmmVars).t)
+      sqMahlist(*, ::) += (sum(gmmMeans :* gmmMeans :/ gmmVars, Axis._1) :+ 0.5)
 
       // compute the log likelihood of the approximate posterior
       val llh = DenseMatrix.ones[Double](numSamples, 1) *


### PR DESCRIPTION
This PR is an attempt to make the Scala GMM faster. I tried a bunch of changes, but the that was most useful was replacing the log-likelihood computation with a while loop. Some numbers from before vs. after 
```
Dataset : 1M points with 80 dimensions. OMP_NUM_THREADS is set to 1
Time is in seconds
Num centers, Old time, With this PR time
64, 383.481, 266.444
32, 214.411, 149.455
16, 90.724, 66.057
```

So we get around 25-30% improvement in performance from this change.

Fixes #174 
