### PR TITLE
Exclude slf4j-simple from Scala NLP deps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,13 +26,19 @@ libraryDependencies ++= Seq(
   "org.apache.commons" % "commons-compress" % "1.7",
   "commons-io" % "commons-io" % "2.4",
   "org.scalanlp" % "breeze_2.10" % "0.11.2",
-  "org.scalanlp" %% "epic-parser-en-span" % "2015.2.19",
-  "org.scalanlp" %% "epic-pos-en" % "2015.2.19",
-  "org.scalanlp" %% "epic-ner-en-conll" % "2015.2.19",
   "com.google.guava" % "guava" % "14.0.1",
   "com.github.fommil.netlib" % "all" % "1.1.2" pomOnly(),
   "com.github.scopt" %% "scopt" % "3.3.0"
 )
+
+{
+  val excludeSLF = ExclusionRule(organization = "org.slf4j")
+  libraryDependencies ++= Seq(
+    "org.scalanlp" %% "epic-parser-en-span" % "2015.2.19" excludeAll(excludeSLF),
+    "org.scalanlp" %% "epic-pos-en" % "2015.2.19" excludeAll(excludeSLF),
+    "org.scalanlp" %% "epic-ner-en-conll" % "2015.2.19" excludeAll(excludeSLF)
+  )
+}
 
 {
   val defaultSparkVersion = "1.5.2"


### PR DESCRIPTION
Not excluding this means that our `log4j.properties` gets ignored as SLF4J uses `slf4j-simple` as the logging backend. To test this you can run `sbt/sbt test` without this change and you should see lines like

```
[Executor task launch worker-0] INFO org.apache.spark.storage.BlockManager - Found block rdd_150_1 locally
```
which will no longer appear with this change