### PR TITLE
Add example pipeline scripts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ project/plugins/project/
 
 # Jekyll stuff
 _site/
+
+# Data for running examples.
+example_data/

--- a/examples/images/cifar_random_patch.sh
+++ b/examples/images/cifar_random_patch.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+#Set environment variables
+: ${KEYSTONE_MEM:=4g}
+export KEYSTONE_MEM
+
+KEYSTONE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../..
+: ${EXAMPLE_DATA_DIR:=$KEYSTONE_DIR/example_data}
+
+if [ ! -d $EXAMPLE_DATA_DIR ]; then
+    mkdir $EXAMPLE_DATA_DIR
+fi
+
+#Download data if necessary.
+if [[ ! ( -f $EXAMPLE_DATA_DIR/cifar_train.bin && -f $EXAMPLE_DATA_DIR/cifar_test.bin ) ]]; then
+    #Get the data
+    wget -O $TMPDIR/cifar-10-binary.tar.gz  http://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz 
+
+    #Decompress it
+    tar zxvf $TMPDIR/cifar-10-binary.tar.gz -C $TMPDIR
+    cat $TMPDIR/cifar-10-batches-bin/data_batch*.bin > $EXAMPLE_DATA_DIR/cifar_train.bin
+    mv $TMPDIR/cifar-10-batches-bin/test_batch.bin $EXAMPLE_DATA_DIR/cifar_test.bin
+       
+    #Clean up. 
+    rm -rf $TMPDIR/cifar-10-batches-bin
+    rm -rf $TMPDIR/cifar-10-binary.tar.gz
+fi
+
+#Run the pipeline
+$KEYSTONE_DIR/bin/run-pipeline.sh \
+  keystoneml.pipelines.images.cifar.RandomPatchCifar \
+  --trainLocation $EXAMPLE_DATA_DIR/cifar_train.bin \
+  --testLocation $EXAMPLE_DATA_DIR/cifar_test.bin \
+  --numFilters 10000 \
+  --lambda 3000 \
+  --whiteningEpsilon 1e-5

--- a/examples/images/mnist_random_fft.sh
+++ b/examples/images/mnist_random_fft.sh
@@ -5,6 +5,9 @@ set -e
 : ${KEYSTONE_MEM:=4g}
 export KEYSTONE_MEM
 
+: ${NUM_FFTS:=4}
+: ${BLOCK_SIZE:=2048}
+
 KEYSTONE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../..
 : ${EXAMPLE_DATA_DIR:=$KEYSTONE_DIR/example_data}
 
@@ -27,5 +30,5 @@ $KEYSTONE_DIR/bin/run-pipeline.sh \
   keystoneml.pipelines.images.mnist.MnistRandomFFT \
   --trainLocation $EXAMPLE_DATA_DIR/train-mnist-dense-with-labels.data \
   --testLocation $EXAMPLE_DATA_DIR/test-mnist-dense-with-labels.data \
-  --numFFTs 4 \
-  --blockSize 2048
+  --numFFTs $NUM_FFTS \
+  --blockSize $BLOCK_SIZE

--- a/examples/images/mnist_random_fft.sh
+++ b/examples/images/mnist_random_fft.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+#Set environment variables
+: ${KEYSTONE_MEM:=4g}
+export KEYSTONE_MEM
+
+KEYSTONE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../..
+: ${EXAMPLE_DATA_DIR:=$KEYSTONE_DIR/example_data}
+
+if [ ! -d $EXAMPLE_DATA_DIR ]; then
+    mkdir $EXAMPLE_DATA_DIR
+fi
+
+# Get the data from S3
+if [ ! -f $EXAMPLE_DATA_DIR/train-mnist-dense-with-labels.data ]; then
+    wget -O $EXAMPLE_DATA_DIR/train-mnist-dense-with-labels.data  \
+        http://mnist-data.s3.amazonaws.com/train-mnist-dense-with-labels.data
+fi
+
+if [ ! -f $EXAMPLE_DATA_DIR/test-mnist-dense-with-labels.data ]; then
+    wget -O $EXAMPLE_DATA_DIR/test-mnist-dense-with-labels.data \
+        http://mnist-data.s3.amazonaws.com/test-mnist-dense-with-labels.data
+fi
+
+$KEYSTONE_DIR/bin/run-pipeline.sh \
+  keystoneml.pipelines.images.mnist.MnistRandomFFT \
+  --trainLocation $EXAMPLE_DATA_DIR/train-mnist-dense-with-labels.data \
+  --testLocation $EXAMPLE_DATA_DIR/test-mnist-dense-with-labels.data \
+  --numFFTs 4 \
+  --blockSize 2048

--- a/examples/images/voc_sift_fisher.sh
+++ b/examples/images/voc_sift_fisher.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+#Set environment variables
+: ${KEYSTONE_MEM:=4g}
+export KEYSTONE_MEM
+
+KEYSTONE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../..
+: ${HADOOP_EXAMPLE_DATA_DIR:=/example_data}
+
+
+#Get the data and copy to HDFS if necessary.
+if [ ! hadoop fs -test -e $HADOOP_EXAMPLE_DATA_DIR/VOCtrainval_06-Nov-2007.tar ]; then
+    wget -O $TMPDIR/VOCtrainval_06-Nov-2007.tar https://s3-us-west-2.amazonaws.com/voc-data/VOCtrainval_06-Nov-2007.tar
+    hadoop fs -copyFromLocal VOCtrainval_06-Nov-2007.tar $HADOOP_EXAMPLE_DATA_DIR
+    rm -f $TMPDIR/VOCtrainval_06-Nov-2007.tar
+fi
+
+if [ ! hadoop fs -test -e $HADOOP_EXAMPLE_DATA_DIR/VOCtest_06-Nov-2007.tar ]; then
+    wget -O $TMPDIR/VOCtest_06-Nov-2007.tar https://s3-us-west-2.amazonaws.com/voc-data/VOCtest_06-Nov-2007.tar
+    hadoop fs -copyFromLocal VOCtest_06-Nov-2007.tar $HADOOP_EXAMPLE_DATA_DIR
+    rm -f $TMPDIR/VOCtest_06-Nov-2007.tar
+fi
+
+#Run the pipeline
+$KEYSTONE_DIR/bin/run-pipeline.sh \
+  keystoneml.pipelines.images.voc.VOCSIFTFisher \
+  --trainLocation $HADOOP_EXAMPLE_DATA_DIR/VOCtrainval_06-Nov-2007.tar \
+  --testLocation $HADOOP_EXAMPLE_DATA_DIR/VOCtest_06-Nov-2007.tar \
+  --labelPath $KEYSTONE_DIR/src/test/resources/images/voclabels.csv \
+  --numParts 200

--- a/examples/images/voc_sift_fisher.sh
+++ b/examples/images/voc_sift_fisher.sh
@@ -2,30 +2,26 @@
 set -e
 
 #Set environment variables
-: ${KEYSTONE_MEM:=4g}
+: ${KEYSTONE_MEM:=12g}
 export KEYSTONE_MEM
 
 KEYSTONE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../..
-: ${HADOOP_EXAMPLE_DATA_DIR:=/example_data}
+: ${EXAMPLE_DATA_DIR:=$KEYSTONE_DIR/example_data}
 
 
 #Get the data and copy to HDFS if necessary.
-if [ ! hadoop fs -test -e $HADOOP_EXAMPLE_DATA_DIR/VOCtrainval_06-Nov-2007.tar ]; then
-    wget -O $TMPDIR/VOCtrainval_06-Nov-2007.tar https://s3-us-west-2.amazonaws.com/voc-data/VOCtrainval_06-Nov-2007.tar
-    hadoop fs -copyFromLocal VOCtrainval_06-Nov-2007.tar $HADOOP_EXAMPLE_DATA_DIR
-    rm -f $TMPDIR/VOCtrainval_06-Nov-2007.tar
+if [ ! -f $EXAMPLE_DATA_DIR/VOCtrainval_06-Nov-2007.tar ]; then
+    wget -O $EXAMPLE_DATA_DIR/VOCtrainval_06-Nov-2007.tar http://s3-us-west-2.amazonaws.com/voc-data/VOCtrainval_06-Nov-2007.tar
 fi
 
-if [ ! hadoop fs -test -e $HADOOP_EXAMPLE_DATA_DIR/VOCtest_06-Nov-2007.tar ]; then
-    wget -O $TMPDIR/VOCtest_06-Nov-2007.tar https://s3-us-west-2.amazonaws.com/voc-data/VOCtest_06-Nov-2007.tar
-    hadoop fs -copyFromLocal VOCtest_06-Nov-2007.tar $HADOOP_EXAMPLE_DATA_DIR
-    rm -f $TMPDIR/VOCtest_06-Nov-2007.tar
+if [ ! -f $EXAMPLE_DATA_DIR/VOCtest_06-Nov-2007.tar ]; then
+    wget -O $EXAMPLE_DATA_DIR/VOCtest_06-Nov-2007.tar http://s3-us-west-2.amazonaws.com/voc-data/VOCtest_06-Nov-2007.tar
 fi
 
 #Run the pipeline
 $KEYSTONE_DIR/bin/run-pipeline.sh \
   keystoneml.pipelines.images.voc.VOCSIFTFisher \
-  --trainLocation $HADOOP_EXAMPLE_DATA_DIR/VOCtrainval_06-Nov-2007.tar \
-  --testLocation $HADOOP_EXAMPLE_DATA_DIR/VOCtest_06-Nov-2007.tar \
+  --trainLocation $EXAMPLE_DATA_DIR/VOCtrainval_06-Nov-2007.tar \
+  --testLocation $EXAMPLE_DATA_DIR/VOCtest_06-Nov-2007.tar \
   --labelPath $KEYSTONE_DIR/src/test/resources/images/voclabels.csv \
   --numParts 200

--- a/examples/text/newsgroups_ngrams_tfidf.sh
+++ b/examples/text/newsgroups_ngrams_tfidf.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+#Set environment variables
+: ${KEYSTONE_MEM:=4g}
+export KEYSTONE_MEM
+
+: ${NUM_PARTS:=256}
+: ${NGRAMS:=2}
+: ${COMMON_FEATURES:=1000}
+
+KEYSTONE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../..
+: ${EXAMPLE_DATA_DIR:=$KEYSTONE_DIR/example_data}
+
+if [ ! -d $EXAMPLE_DATA_DIR ]; then
+    mkdir $EXAMPLE_DATA_DIR
+fi
+
+
+#Download 20 Newsgroups data if necessary.
+if [ ! -f $EXAMPLE_DATA_DIR/20news-bydate.tar.gz ]; then
+    wget -O $EXAMPLE_DATA_DIR/20news-bydate.tar.gz http://qwone.com/~jason/20Newsgroups/20news-bydate.tar.gz
+    tar zxvf $EXAMPLE_DATA_DIR/20news-bydate.tar.gz -C $EXAMPLE_DATA_DIR
+fi
+
+#Run pipeline.
+$KEYSTONE_DIR/bin/run-pipeline.sh \
+    keystoneml.pipelines.text.NewsgroupsPipeline \
+    --trainLocation $EXAMPLE_DATA_DIR/20news-bydate-train \
+    --testLocation $EXAMPLE_DATA_DIR/20news-bydate-test \
+    --nGrams $NGRAMS \
+    --commonFeatures $COMMON_FEATURES


### PR DESCRIPTION
Fixes #289 

This PR adds three example scripts that will actually download data and run pipelines for four of the example pipelines that ship with keystone.